### PR TITLE
chore(cleanup): remove unused ch_batch_reports

### DIFF
--- a/subworkflows/local/taxonomic_classification/main.nf
+++ b/subworkflows/local/taxonomic_classification/main.nf
@@ -373,7 +373,6 @@ workflow TAXONOMIC_CLASSIFICATION {
                 // Use final cumulative report for downstream (TAXPASTA, KRONA, MultiQC)
                 // Per-batch reports would produce 720 files for 24 barcodes x 30 batches
                 ch_raw_reports = KRAKEN2_FINAL_AGGREGATOR.out.cumulative_report
-                ch_batch_reports = KRAKEN2_REPORT_GENERATOR.out.report
                 ch_performance_metrics = KRAKEN2_REPORT_GENERATOR.out.stats
 
             } else if (use_optimizations == true) {


### PR DESCRIPTION
## Summary
Removes a write-only local channel assignment in the incremental classification branch of the TAXONOMIC_CLASSIFICATION subworkflow. \`ch_batch_reports\` was assigned from \`KRAKEN2_REPORT_GENERATOR.out.report\` but never read or emitted by this subworkflow.

ripgrep confirmation across the repository:
- Only assignment: \`subworkflows/local/taxonomic_classification/main.nf:376\`
- Mentions in \`docs/development/incremental_kraken2_implementation.md\` describe a different example workflow.
- No \`emit:\` block of TAXONOMIC_CLASSIFICATION exposes this name.

## Test plan
- [x] \`nf-test test subworkflows/local/taxonomic_classification/tests/main.nf.test subworkflows/local/taxonomic_classification/tests/gui_filename_compatibility.nf.test --profile conda\` (env nf-core)
- [x] Compared with baseline run on dev (no edit): 12 tests, 8 failures both before and after. Failures are pre-existing snapshot drift and an unrelated IndexOutOfBoundsException; they do not change with this removal.

## Notes
No public-facing channel removed. The four passing tests continue to pass.