### PR TITLE
fix(taxonomic_classification): drop ifEmpty([]) and refresh snapshots

### DIFF
--- a/subworkflows/local/taxonomic_classification/main.nf
+++ b/subworkflows/local/taxonomic_classification/main.nf
@@ -396,7 +396,7 @@ workflow TAXONOMIC_CLASSIFICATION {
                 ch_classified_reads = KRAKEN2_OPTIMIZED.out.classified_reads_fastq.ifEmpty([])
                 ch_unclassified_reads = KRAKEN2_OPTIMIZED.out.unclassified_reads_fastq.ifEmpty([])
                 ch_reads_assignment = KRAKEN2_OPTIMIZED.out.classified_reads_assignment.ifEmpty([])
-                ch_raw_reports = KRAKEN2_OPTIMIZED.out.report.ifEmpty([])
+                ch_raw_reports = KRAKEN2_OPTIMIZED.out.report
                 ch_performance_metrics = KRAKEN2_OPTIMIZED.out.performance_metrics.ifEmpty([])
             } else {
                 KRAKEN2_KRAKEN2 (
@@ -412,7 +412,7 @@ workflow TAXONOMIC_CLASSIFICATION {
                 ch_classified_reads = KRAKEN2_KRAKEN2.out.classified_reads_fastq.ifEmpty([])
                 ch_unclassified_reads = KRAKEN2_KRAKEN2.out.unclassified_reads_fastq.ifEmpty([])
                 ch_reads_assignment = KRAKEN2_KRAKEN2.out.classified_reads_assignment.ifEmpty([])
-                ch_raw_reports = KRAKEN2_KRAKEN2.out.report.ifEmpty([])
+                ch_raw_reports = KRAKEN2_KRAKEN2.out.report
                 ch_performance_metrics = Channel.empty()
             }
             break

--- a/subworkflows/local/taxonomic_classification/tests/main.nf.test.snap
+++ b/subworkflows/local/taxonomic_classification/tests/main.nf.test.snap
@@ -2,14 +2,13 @@
     "Should handle multiple classification formats": {
         "content": [
             [
-                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc",
-                "versions.yml:md5,2a76abe3730755e7196b7ab4e28e196f"
+                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc"
             ]
         ],
-        "timestamp": "2026-04-26T08:42:27.539828",
+        "timestamp": "2026-05-08T23:38:04.199567",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Should process multiple samples in batch": {
@@ -17,82 +16,73 @@
             [
                 "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc",
                 "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc",
-                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc",
-                "versions.yml:md5,2a76abe3730755e7196b7ab4e28e196f",
-                "versions.yml:md5,2a76abe3730755e7196b7ab4e28e196f",
-                "versions.yml:md5,2a76abe3730755e7196b7ab4e28e196f"
+                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc"
             ]
         ],
-        "timestamp": "2026-04-26T08:43:18.879391",
+        "timestamp": "2026-05-08T23:39:00.476431",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Should perform basic Kraken2 taxonomic classification": {
         "content": [
             [
-                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc",
-                "versions.yml:md5,2a76abe3730755e7196b7ab4e28e196f"
+                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc"
             ]
         ],
-        "timestamp": "2026-04-26T08:41:35.741761",
+        "timestamp": "2026-05-08T23:37:08.351096",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Should support different Kraken2 database types": {
         "content": [
             [
-                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc",
-                "versions.yml:md5,2a76abe3730755e7196b7ab4e28e196f"
+                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc"
             ]
         ],
-        "timestamp": "2026-04-26T08:46:04.858245",
+        "timestamp": "2026-05-08T23:43:00.820389",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Should handle classification confidence thresholds": {
         "content": [
             [
-                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc",
-                "versions.yml:md5,2a76abe3730755e7196b7ab4e28e196f"
+                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc"
             ]
         ],
-        "timestamp": "2026-04-26T08:44:10.568791",
+        "timestamp": "2026-05-08T23:39:57.130639",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Should handle empty input gracefully": {
         "content": [
             [
-                [
-                    
-                ]
+                
             ]
         ],
-        "timestamp": "2026-04-26T08:45:09.24298",
+        "timestamp": "2026-05-08T23:41:29.092513",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     },
     "Should standardize output with Taxpasta": {
         "content": [
             [
-                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc",
-                "versions.yml:md5,2a76abe3730755e7196b7ab4e28e196f"
+                "versions.yml:md5,1ff71baa7b75ae556d2bbb257164a2dc"
             ]
         ],
-        "timestamp": "2026-04-26T08:45:04.751614",
+        "timestamp": "2026-05-08T23:41:23.3096",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.04.7"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
         }
     }
 }


### PR DESCRIPTION
## Summary

Two `ch_raw_reports = ...ifEmpty([])` assignments emitted a literal empty
list `[]` into the channel when the upstream Kraken2 process never ran
(every input sample took the empty-FASTQ skip branch). The list mixed
with `EMIT_EMPTY_KRAKEN2_REPORT.out.report` and reached the public
`workflow.out.report`, where nf-test 0.9.5 threw
`IndexOutOfBoundsException` introspecting the malformed `[[], [meta, file]]`
entry. `Channel.mix` already handles empty operands; the `ifEmpty([])`
was always wrong, only surfaced now that the empty-input path always
routes through the placeholder emitter (commit 600e6ff).

Snapshots regenerated to reflect:
1. The corrected empty-channel behaviour
2. The byte-size filter at line 459 that excludes 0-byte stub reports
   from TAXPASTA versions output

## Audit
Authored by Agent E (`eval/snapshot-regen` worktree) during the
2026-05-08 eval. The agent stopped at the snapshot-only step on
discovering the underlying bug; this PR carries the source fix +
regenerated snapshots together.

## Test plan
- [x] `nf-test test subworkflows/local/taxonomic_classification/tests/main.nf.test --profile conda` -> 8/8 pass
- [x] Snapshot diff inspected: 7 cases drop only the stale TAXPASTA versions hash; no path or hash drift in unrelated files