### PR TITLE
docs(p2.9): clarify max_concurrent_batches is advisory only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,15 @@ outdir/kraken2/
 
 ```groovy
 // Scalable streaming architecture (v1.5+)
-max_concurrent_batches   = 4    // Backpressure limit per sample
-max_classification_forks = 8    // Max parallel Kraken2 jobs
+max_concurrent_batches   = 4    // ADVISORY (not enforced; see audit P2.9)
+max_classification_forks = 8    // Max parallel Kraken2 jobs (global cap, enforced via process maxForks)
 ```
+
+> `max_concurrent_batches` is logged for visibility but has no
+> enforcement effect today. Per-barcode backpressure is tracked under
+> audit item P2.9. Operators who see one slow barcode starving others
+> should raise `--max_classification_forks` proportionally to the
+> barcode count.
 
 ---
 
@@ -352,7 +358,7 @@ NFT_SHARD=2/4 ./tests/run_tests.sh full
 
 ### Scalable Streaming (v1.5+)
 
-- `--max_concurrent_batches` - Backpressure limit per sample (default: 4)
+- `--max_concurrent_batches` - Advisory only; not currently enforced (default: 4, see audit P2.9)
 - `--max_classification_forks` - Max parallel Kraken2 jobs (default: 8)
 - `--kraken2_enable_incremental` - Enable scalable streaming architecture
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -733,9 +733,9 @@
                     "default": 4,
                     "minimum": 1,
                     "maximum": 32,
-                    "description": "Maximum concurrent batches per sample for backpressure control.",
+                    "description": "Maximum concurrent batches per barcode (advisory; not currently enforced).",
                     "fa_icon": "fas fa-traffic-light",
-                    "help_text": "Limits the number of batches that can be processed concurrently per sample to prevent queue saturation. Increase for systems with more memory and CPU cores."
+                    "help_text": "Reserved for the per-barcode throttle tracked under audit item P2.9. Today this value is logged for visibility but has no enforcement effect: the only real classifier throttle is the global ``--max_classification_forks`` cap on the Kraken2 process declarations. If one slow barcode is starving others, raise ``--max_classification_forks`` to at least the number of barcodes so each barcode can land one classifier slot in steady state."
                 },
                 "max_classification_forks": {
                     "type": "integer",

--- a/subworkflows/local/realtime_monitoring/main.nf
+++ b/subworkflows/local/realtime_monitoring/main.nf
@@ -33,12 +33,33 @@ workflow REALTIME_MONITORING {
 
         //
         // BACKPRESSURE CONFIGURATION (v1.5+)
-        // Limits concurrent processing to prevent queue saturation
         //
-        def max_concurrent = params.max_concurrent_batches ?: 4
-        log.info "Backpressure: max ${max_concurrent} concurrent batches per sample"
-        log.info "Classification forks: ${params.max_classification_forks ?: 8} parallel Kraken2 jobs"
-        log.info "Batch timeout: ${params.batch_timeout ?: 60} seconds"
+        // ``max_classification_forks`` is enforced by ``maxForks`` on
+        // the KRAKEN2_INCREMENTAL_CLASSIFIER / KRAKEN2_OPTIMIZED /
+        // KRAKEN2_KRAKEN2 process declarations in conf/modules.config.
+        // It is a *global* fork cap across all in-flight classification
+        // tasks, regardless of which barcode emitted them.
+        //
+        // ``max_concurrent_batches`` is currently *advisory only*. The
+        // intent (one barcode cannot occupy more than N classifier
+        // slots) cannot be expressed cleanly in Nextflow DSL2 because
+        // ``maxForks`` is per-process, not per-key. The audit P2.9
+        // item tracks the work to add a per-key throttle (likely a
+        // custom Groovy operator in lib/BatchUtils.groovy that wraps
+        // a per-sample semaphore over the batches channel). Until then,
+        // operators who see a single slow barcode starve others should
+        // raise ``--max_classification_forks`` proportionally to the
+        // number of barcodes -- e.g. on a 24-plex run set forks to at
+        // least 6 so every barcode can land at least one classifier
+        // slot in steady state.
+        //
+        def max_classification_forks = params.max_classification_forks ?: 8
+        def batch_timeout = params.batch_timeout ?: 60
+        log.info "Backpressure: classifier maxForks = ${max_classification_forks} (global cap, not per-barcode)"
+        log.info "Batch timeout: ${batch_timeout} seconds"
+        if (params.max_concurrent_batches != null) {
+            log.info "NOTE: ``--max_concurrent_batches ${params.max_concurrent_batches}`` is currently advisory; see audit P2.9 for the planned per-barcode throttle"
+        }
 
         // Use file() function directly to find existing files - more reliable than Channel.fromPath
         // The file() function with glob patterns returns a list of matching files


### PR DESCRIPTION
## Summary

The audit P2.9 finding asked for per-barcode backpressure: one slow barcode shouldn't starve the others. Investigation shows \`max_concurrent_batches\` is read into a local variable in \`realtime_monitoring/main.nf\` and **printed only** -- there's no enforcement anywhere. The only real classifier throttle is the global \`max_classification_forks\` cap.

Implementing a true per-barcode throttle in Nextflow DSL2 requires a custom Groovy operator (likely layered onto \`lib/BatchUtils.groovy\`) because \`maxForks\` is per-process, not per-key. That surgery is deferred.

This PR does the honest middle step:

- Remove the unused \`max_concurrent\` local and replace the misleading "Backpressure: max N per sample" log line with one that states the real situation (global \`max_classification_forks\` cap). When the operator passes \`--max_concurrent_batches\`, emit an explicit advisory log so they know it has no effect today.
- Update the schema \`description\` / \`help_text\` to call out the advisory-only status and point to \`--max_classification_forks\` as the workaround.
- Update \`CLAUDE.md\`'s "Concurrency Parameters" block and the parameter quick-reference table to match.

## Test plan

- [x] \`nf-core pipelines schema lint\` -- clean (120 params).
- [x] \`nf-test test tests/multiplex_scaling.nf.test\` -- 3/3 PASS locally.
- [ ] CI (nf-test matrix, profile-sanity, verify-pipeline, lint).

## Audit context

Audit plan at \`/Users/andreassjodin/.claude/plans/make-an-audit-of-steady-iverson.md\`. Remaining P2 item (bounded cumulative state, P2.15) ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)