### PR TITLE
chore: P3 housekeeping -- qc_benchmark wiring, type hints

### DIFF
--- a/bin/kreport_to_canonical.py
+++ b/bin/kreport_to_canonical.py
@@ -11,9 +11,10 @@ import os
 import sys
 import tempfile
 from datetime import datetime, timezone
+from typing import Any, Dict, List, Tuple
 
 
-def parse_kreport(filepath):
+def parse_kreport(filepath: str) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
     """Parse a kreport file and return taxa with hierarchy information.
 
     The kreport format uses leading whitespace on the taxon name to encode
@@ -92,7 +93,7 @@ def parse_kreport(filepath):
     return summary, taxa
 
 
-def write_atomic(filepath, data):
+def write_atomic(filepath: str, data: Any) -> None:
     """Write JSON data atomically using a temporary file and rename."""
     dir_name = os.path.dirname(filepath) or "."
     os.makedirs(dir_name, exist_ok=True)
@@ -108,7 +109,7 @@ def write_atomic(filepath, data):
         raise
 
 
-def build_sidecar(args, source_file):
+def build_sidecar(args: argparse.Namespace, source_file: str) -> Dict[str, Any]:
     """Build sidecar metadata JSON."""
     sidecar = {
         "contract_version": "1.0.0",
@@ -131,7 +132,7 @@ def build_sidecar(args, source_file):
     return sidecar
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Convert kreport TSV to canonical classification JSON."
     )

--- a/bin/qc_to_canonical.py
+++ b/bin/qc_to_canonical.py
@@ -14,9 +14,10 @@ import os
 import sys
 import tempfile
 from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
 
 
-def compute_n50(length_counts):
+def compute_n50(length_counts: List[Tuple[int, int]]) -> Optional[int]:
     """Compute N50 from a list of (length, count) tuples.
 
     Given a histogram of read lengths, N50 is the length at which 50% of
@@ -39,7 +40,7 @@ def compute_n50(length_counts):
     return None
 
 
-def parse_fastp(filepath):
+def parse_fastp(filepath: str) -> Dict[str, Any]:
     """Parse FASTP JSON and extract QC statistics."""
     with open(filepath, "r") as f:
         data = json.load(f)
@@ -127,7 +128,7 @@ def parse_fastp(filepath):
     return result
 
 
-def parse_seqkit(filepath):
+def parse_seqkit(filepath: str) -> Dict[str, Any]:
     """Parse SeqKit TSV output and extract QC statistics.
 
     Expected columns: num_seqs, sum_len, min_len, avg_len, max_len,
@@ -177,7 +178,7 @@ def parse_seqkit(filepath):
     return result
 
 
-def write_atomic(filepath, data):
+def write_atomic(filepath: str, data: Any) -> None:
     """Write JSON data atomically using a temporary file and rename."""
     dir_name = os.path.dirname(filepath) or "."
     os.makedirs(dir_name, exist_ok=True)
@@ -193,7 +194,7 @@ def write_atomic(filepath, data):
         raise
 
 
-def build_sidecar(args):
+def build_sidecar(args: argparse.Namespace) -> Dict[str, Any]:
     """Build sidecar metadata JSON."""
     sidecar = {
         "contract_version": "1.0.0",
@@ -213,7 +214,7 @@ def build_sidecar(args):
     return sidecar
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Convert FASTP JSON or SeqKit TSV to canonical QC JSON."
     )

--- a/bin/write_manifest.py
+++ b/bin/write_manifest.py
@@ -11,9 +11,10 @@ import os
 import sys
 import tempfile
 from datetime import datetime, timezone
+from typing import Any, List
 
 
-def write_atomic(filepath, data):
+def write_atomic(filepath: str, data: Any) -> None:
     """Write JSON data atomically using a temporary file and rename."""
     dir_name = os.path.dirname(filepath) or "."
     os.makedirs(dir_name, exist_ok=True)
@@ -29,7 +30,7 @@ def write_atomic(filepath, data):
         raise
 
 
-def discover_files(outdir, category, extension):
+def discover_files(outdir: str, category: str, extension: str) -> List[str]:
     """Discover canonical output files for a given category.
 
     Scans the category subdirectory under outdir for files matching the
@@ -46,7 +47,7 @@ def discover_files(outdir, category, extension):
     return files
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Write or update canonical/_manifest.json."
     )

--- a/subworkflows/local/qc_benchmark/main.nf
+++ b/subworkflows/local/qc_benchmark/main.nf
@@ -20,13 +20,14 @@
 ----------------------------------------------------------------------------------------
 */
 
-include { FASTP                   } from '../../../modules/nf-core/fastp/main'
-include { FILTLONG                } from '../../../modules/nf-core/filtlong/main'
-include { CHOPPER                 } from '../../../modules/nf-core/chopper/main'
-include { PORECHOP_PORECHOP       } from '../../../modules/nf-core/porechop/porechop/main'
-include { FASTQC                  } from '../../../modules/nf-core/fastqc/main'
-include { SEQKIT_STATS            } from '../../../modules/nf-core/seqkit/stats/main'
-include { NANOPLOT                } from '../../../modules/nf-core/nanoplot/main'
+include { FASTP                                 } from '../../../modules/nf-core/fastp/main'
+include { FILTLONG                              } from '../../../modules/nf-core/filtlong/main'
+include { FILTLONG as FILTLONG_AFTER_PORECHOP   } from '../../../modules/nf-core/filtlong/main'
+include { CHOPPER                               } from '../../../modules/nf-core/chopper/main'
+include { PORECHOP_PORECHOP                     } from '../../../modules/nf-core/porechop/porechop/main'
+include { FASTQC                                } from '../../../modules/nf-core/fastqc/main'
+include { SEQKIT_STATS                          } from '../../../modules/nf-core/seqkit/stats/main'
+include { NANOPLOT                              } from '../../../modules/nf-core/nanoplot/main'
 
 workflow QC_BENCHMARK {
 
@@ -131,21 +132,24 @@ workflow QC_BENCHMARK {
         [meta, null, reads]  // [meta, shortreads=empty, longreads=reads]
     }
 
-    // Run FILTLONG on adapter-trimmed reads (simplified for now)
-    // TODO: Re-implement with proper module aliasing or separate workflows
-    // FILTLONG_PORECHOP would go here
+    // PORECHOP -> FILTLONG pipeline, run as a second aliased FILTLONG
+    // instance so the standalone FILTLONG benchmark above can keep its
+    // distinct work directory and outputs. Using ``include as`` for the
+    // alias is the canonical DSL2 pattern for re-running a process with
+    // a different input feed (see e.g. nf-core/eager and nf-core/sarek).
+    FILTLONG_AFTER_PORECHOP (
+        ch_porechop_filtlong_input
+    )
+    ch_versions = ch_versions.mix(FILTLONG_AFTER_PORECHOP.out.versions.first())
 
-    // For now, skip the PORECHOP+FILTLONG combination to avoid aliasing issues
-    // This maintains basic benchmarking functionality while avoiding compilation errors
-
-    // Create PORECHOP+FILTLONG benchmark record (simplified - using PORECHOP output directly)
-    ch_porechop_filtlong_benchmark = PORECHOP_PORECHOP.out.reads
-        .map { meta, reads ->
+    ch_porechop_filtlong_benchmark = FILTLONG_AFTER_PORECHOP.out.reads
+        .join(FILTLONG_AFTER_PORECHOP.out.log, by: 0, remainder: true)
+        .map { meta, reads, log_file ->
             def new_meta = meta + [
-                qc_tool: 'porechop_only',
+                qc_tool: 'porechop_filtlong',
                 benchmark_category: 'enhanced_nanopore'
             ]
-            return [new_meta, reads, null, null]  // Empty log and stats for now
+            return [new_meta, reads, log_file, null]
         }
 
     //


### PR DESCRIPTION
## Summary

Three small follow-ups from the production-readiness audit's P3 section (after the P0+P1 and full P2 sets landed in PRs #11–#15).

- **P3.16** -- \`subworkflows/local/qc_benchmark/main.nf\` carried a TODO at line 135 that skipped the PORECHOP -> FILTLONG pipeline and labelled the resulting benchmark row as \`porechop_only\`, which made the qc_benchmark output misleading whenever \`--enable_qc_benchmark\` was true. Wire the second FILTLONG invocation in properly through an \`include as\` alias (\`FILTLONG_AFTER_PORECHOP\`) -- the canonical DSL2 pattern for re-running a process on a different feed -- and re-label the row as \`porechop_filtlong\`.

- **P3.17** -- no-op. The audit recommended bumping chopper to 0.12.1+, but the upstream GitHub release page shows \`v0.12.0b\` is still the latest tag, so the existing pin already tracks upstream. Marked complete and documented in the commit for the audit trail.

- **P3.18** -- the canonical writer scripts (\`kreport_to_canonical\`, \`qc_to_canonical\`, \`write_manifest\`) had no type hints, while the rest of \`bin/\` does. Add PEP 484 hints on the public functions for consistency. No behavioural change.

## Test plan

- [x] \`python3 -m py_compile bin/{kreport,qc,write_manifest}.py\` clean.
- [x] \`nf-test test tests/multiplex_scaling.nf.test\` -- 3/3 PASS locally (~73 s).
- [x] \`nf-core pipelines schema lint\` -- clean.
- [ ] CI matrix (nf-test 26.04.0 + latest-everything, profile-sanity, verify-pipeline, lint).

## Audit context

This closes the audit's P3 section. The audit plan at \`/Users/andreassjodin/.claude/plans/make-an-audit-of-steady-iverson.md\` is now fully addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)