### PR TITLE
feat(v5): runtime metrics for backpressure observability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,6 +362,23 @@ NFT_SHARD=2/4 ./tests/run_tests.sh full
 - `--max_classification_forks` - Max parallel Kraken2 jobs (default: 8)
 - `--kraken2_enable_incremental` - Enable scalable streaming architecture
 
+### Runtime metrics (audit V5)
+
+- `--runtime_metrics_interval_seconds` - Interval (s) for periodic
+  `[runtime-metrics]` snapshots emitted by `REALTIME_MONITORING`.
+  Default `0` (off); set e.g. `--runtime_metrics_interval_seconds 60`
+  on a 24-barcode field run to collect the queue-depth evidence the
+  audit asked for. Combined with the expanded `trace.fields`
+  (`submit / start / complete / queue`) the resulting
+  `execution_trace_*.txt` lets you chart per-task waiting time and
+  per-barcode batch counts without instrumenting Nextflow internals.
+  Grep `.nextflow.log` for `[runtime-metrics]` to extract:
+
+  ```
+  [runtime-metrics] elapsed_s=N files=X batches=Y barcodes=Z \
+      batches_per_barcode_min=A batches_per_barcode_max=B
+  ```
+
 ### Taxonomic Classification
 
 - `--kraken2_db` - Path to Kraken2 database

--- a/nextflow.config
+++ b/nextflow.config
@@ -71,6 +71,14 @@ params {
     max_classification_forks   = 4           // Max parallel Kraken2 classification jobs (fewer forks = less memory pressure, better cache reuse)
     report_write_interval      = 5           // Write progressive cumulative report every N batches (0 = every batch)
 
+    // Audit V5 instrumentation. When > 0 the realtime_monitoring subworkflow
+    // emits a structured ``[runtime-metrics]`` log line every N seconds with
+    // live file / batch / per-barcode counters. Combined with the expanded
+    // ``trace.fields`` block lower in this file (submit / start / queue),
+    // this gives a 24-barcode field run the data the audit asked for. 0 keeps
+    // batch-mode runs silent.
+    runtime_metrics_interval_seconds = 0
+
     // Resource ceilings (referenced by platform profiles via params.max_cpus /
     // params.max_memory / params.max_time). Declared here so platform configs
     // can read them without runtime null-reference warnings under strict-mode
@@ -415,6 +423,15 @@ trace {
     enabled   = true
     overwrite = true
     file      = "${params.outdir}/pipeline_info/execution_trace_${params.trace_report_suffix}.txt"
+    // Default trace fields drop ``start``, so post-hoc queue-depth
+    // analysis cannot compute per-task waiting time. Expand the field
+    // list to include submit / start / complete (and the cumulative
+    // queue-wait helper introduced in Nextflow 23.x), so a 24-barcode
+    // field run yields trace data that ``audit V5`` can chart without
+    // re-running the pipeline. The per-task line size grows by ~40 B
+    // each, which is negligible at the ~10k-task scale of a typical
+    // streaming run.
+    fields    = 'task_id,hash,native_id,process,tag,name,status,exit,submit,start,complete,duration,realtime,queue,%cpu,%mem,peak_rss,peak_vmem,rchar,wchar,attempt'
 }
 dag {
     enabled   = true

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -745,6 +745,15 @@
                     "description": "Maximum parallel Kraken2 classification jobs.",
                     "fa_icon": "fas fa-code-branch",
                     "help_text": "Controls the number of concurrent Kraken2 classification processes. Adjust based on available memory and CPU cores. Each Kraken2 job requires 12GB+ memory with large databases."
+                },
+                "runtime_metrics_interval_seconds": {
+                    "type": "integer",
+                    "default": 0,
+                    "minimum": 0,
+                    "maximum": 3600,
+                    "description": "Interval in seconds for the realtime_monitoring [runtime-metrics] snapshot (0 = disabled).",
+                    "fa_icon": "fas fa-chart-line",
+                    "help_text": "Audit V5 instrumentation. When > 0 the realtime_monitoring subworkflow logs a structured ``[runtime-metrics] elapsed_s=N files=X batches=Y barcodes=Z batches_per_barcode_min=A batches_per_barcode_max=B`` line every N seconds. Combined with the expanded ``trace.fields`` (submit / start / complete / queue) this gives a 24-barcode field run the data the audit asked for to confirm backpressure behaviour. Default 0 (off) keeps batch-mode runs silent."
                 }
             }
         },

--- a/subworkflows/local/realtime_monitoring/main.nf
+++ b/subworkflows/local/realtime_monitoring/main.nf
@@ -61,6 +61,56 @@ workflow REALTIME_MONITORING {
             log.info "NOTE: ``--max_concurrent_batches ${params.max_concurrent_batches}`` is currently advisory; see audit P2.9 for the planned per-barcode throttle"
         }
 
+        //
+        // RUNTIME METRICS SNAPSHOTS (audit V5)
+        //
+        // Audit V5 asked for "live or simulated 24-barcode run with
+        // executor queue-depth metrics collected from .nextflow.log to
+        // confirm backpressure behaviour". Two complementary streams
+        // satisfy that request without instrumenting Nextflow internals:
+        //   1. ``trace.fields`` in nextflow.config now exports submit /
+        //      start / complete / queue, so post-hoc analysis can chart
+        //      per-task waiting time directly from
+        //      ``execution_trace_<ts>.txt``.
+        //   2. This block runs a daemon Timer that periodically emits a
+        //      structured ``[runtime-metrics]`` log line with the live
+        //      counters (files seen, batches emitted, per-barcode batch
+        //      counts). Operators can grep ``.nextflow.log`` for
+        //      ``[runtime-metrics]`` and pipe through ``jq`` / ``awk``.
+        //
+        // The interval is controlled by ``params.runtime_metrics_interval_seconds``.
+        // Default 0 (disabled) keeps batch-mode runs silent; field
+        // operators set e.g. ``--runtime_metrics_interval_seconds 60``
+        // when collecting V5 evidence on a 24-barcode run.
+        //
+        def metrics_interval_s = (params.runtime_metrics_interval_seconds ?: 0) as int
+        def files_seen = new java.util.concurrent.atomic.AtomicLong(0L)
+        def batches_emitted = new java.util.concurrent.atomic.AtomicLong(0L)
+        def per_barcode_batches = new java.util.concurrent.ConcurrentHashMap<String, java.util.concurrent.atomic.AtomicLong>()
+        if (metrics_interval_s > 0) {
+            log.info "[runtime-metrics] periodic snapshot enabled, interval = ${metrics_interval_s}s"
+            def started_at = System.currentTimeMillis()
+            def period_ms = metrics_interval_s * 1000L
+            def metrics_timer = new java.util.Timer('runtime-metrics-snapshot', /* daemon */ true)
+            metrics_timer.scheduleAtFixedRate({
+                try {
+                    long elapsed_s = (System.currentTimeMillis() - started_at) / 1000L
+                    long files = files_seen.get()
+                    long batches = batches_emitted.get()
+                    long sample_count = per_barcode_batches.size()
+                    long max_per_sample = per_barcode_batches.values()
+                        .collect { it.get() }
+                        .max() ?: 0L
+                    long min_per_sample = per_barcode_batches.values()
+                        .collect { it.get() }
+                        .min() ?: 0L
+                    log.info "[runtime-metrics] elapsed_s=${elapsed_s} files=${files} batches=${batches} barcodes=${sample_count} batches_per_barcode_min=${min_per_sample} batches_per_barcode_max=${max_per_sample}"
+                } catch (Exception e) {
+                    log.debug "[runtime-metrics] snapshot failed: ${e.message}"
+                }
+            } as java.util.TimerTask, period_ms, period_ms)
+        }
+
         // Use file() function directly to find existing files - more reliable than Channel.fromPath
         // The file() function with glob patterns returns a list of matching files
         def full_pattern = "${watch_dir}/${file_pattern}"
@@ -157,6 +207,17 @@ workflow REALTIME_MONITORING {
         // With both bounds wired in, whichever predicate is satisfied first
         // terminates the channel; downstream batching then drains naturally.
         def TIMEOUT_SENTINEL = '__REALTIME_TIMEOUT_SENTINEL__'
+
+        // Count every file seen, regardless of whether it survives the
+        // timeout or max_files cuts below. The tap is a side-effect-only
+        // ``.map`` so it does not change the channel shape; the counter
+        // feeds the periodic ``[runtime-metrics]`` snapshot above.
+        if (metrics_interval_s > 0) {
+            ch_all_files = ch_all_files.map { f ->
+                files_seen.incrementAndGet()
+                return f
+            }
+        }
         ch_input_files = ch_all_files
 
         if (params.realtime_timeout_minutes) {
@@ -280,6 +341,24 @@ workflow REALTIME_MONITORING {
         }
 
         log.info "="*80
+
+        // Tap each batch into the runtime-metrics counters before it
+        // flows into the meta-map conversion. ``per_barcode_batches``
+        // is keyed by the parent-directory name (typically the barcode
+        // folder), so the snapshot can report which barcode is moving
+        // and which is starving.
+        if (metrics_interval_s > 0) {
+            ch_batched_files = ch_batched_files.map { batch ->
+                batches_emitted.incrementAndGet()
+                def files = batch instanceof List ? batch : [batch]
+                files.each { f ->
+                    def key = f?.parent?.name ?: 'unknown'
+                    def counter = per_barcode_batches.computeIfAbsent(key, { new java.util.concurrent.atomic.AtomicLong(0L) })
+                    counter.incrementAndGet()
+                }
+                return batch
+            }
+        }
 
         //
         // CHANNEL: Convert files to meta map format with barcode extraction


### PR DESCRIPTION
## Summary

Audit V5 asked for "live or simulated 24-barcode run with executor queue-depth metrics collected from \`.nextflow.log\` to confirm backpressure behaviour". A live 24-barcode run is outside the scope of this PR, but the instrumentation it depends on lands now so the data is available the moment somebody triggers it.

### Two complementary streams

1. **Expanded \`trace.fields\`** in \`nextflow.config\` adds \`submit, start, complete, queue\` to the default set. Post-hoc analysis can chart per-task waiting time (\`start - submit\`) straight out of \`execution_trace_<ts>.txt\` without re-running the pipeline. Row size grows by ~40 B -- negligible at ~10 k tasks per streaming run.

2. **Periodic \`[runtime-metrics]\` log line** in \`subworkflows/local/realtime_monitoring/main.nf\`, emitted by a daemon \`Timer\` (same pattern already used in \`lib/BatchUtils.groovy\`):

   ```
   [runtime-metrics] elapsed_s=N files=X batches=Y barcodes=Z \
       batches_per_barcode_min=A batches_per_barcode_max=B
   ```

   Counters are \`AtomicLong\` / \`ConcurrentHashMap\` so the side-effect \`map\` taps on \`ch_all_files\` and \`ch_batched_files\` cannot race the timer thread. The min/max per barcode is what lets a 24-plex operator see at a glance whether one barcode is starving the queue.

### Configuration

New \`--runtime_metrics_interval_seconds\` parameter (default \`0\` = disabled). Schema entry, default in \`nextflow.config\`, and a brief section in \`CLAUDE.md\` document the workflow. Field operators collecting V5 evidence run with \`--runtime_metrics_interval_seconds 60\`.

## Test plan

- [x] \`nf-core pipelines schema lint\` -- clean (121 params).
- [x] \`nf-test test tests/multiplex_scaling.nf.test tests/full_pipeline_stubmode.nf.test\` -- 7/7 PASS locally (~120 s).
- [ ] CI matrix (nf-test 26.04.0 + latest-everything, profile-sanity, verify-pipeline, lint).

## Audit context

Audit plan at \`/Users/andreassjodin/.claude/plans/make-an-audit-of-steady-iverson.md\`. This addresses verification item V5. Item V4 (ifEmpty regression test) remains; items V2 / V5-live / §8 require real hardware or are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)