### PR TITLE
test(v4): no-Docker regression for ifEmpty([]) crash + fix one missed call site

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -81,6 +81,7 @@ jobs:
             tests/chopper_specific.nf.test \
             tests/default.nf.test \
             tests/full_pipeline_stubmode.nf.test \
+            tests/ifempty_sentinel_regression.nf.test \
             tests/input_scanner.nf.test \
             tests/main_workflow.nf.test \
             tests/multiplex_scaling.nf.test \

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -71,6 +71,7 @@ lint:
     - tests/qc_tool_integration.nf.test
     - tests/full_pipeline_stubmode.nf.test
     - tests/multiplex_scaling.nf.test
+    - tests/ifempty_sentinel_regression.nf.test
   # The .github/workflows/nf-test.yml in this repo is a customised CI matrix
   # (the wrapper at bin/run-nf-tests.sh sets NXF_OFFLINE only) and
   # does not match the nf-core community-template event triggers. The

--- a/tests/ifempty_sentinel_regression.config
+++ b/tests/ifempty_sentinel_regression.config
@@ -1,0 +1,21 @@
+// Test-only config for tests/ifempty_sentinel_regression.nf.test
+//
+// Audit V4 / PR #11 P0.1 regression cover. Forces every CHOPPER task
+// to be skipped at scheduling time via ``ext.when = false``. Skipped
+// processes emit nothing on their output channels, so the downstream
+// ``CHOPPER.out.fastq.ifEmpty([])`` operator in
+// subworkflows/local/qc_analysis/main.nf:204 fires the ``[]`` sentinel
+// without needing the CHOPPER binary, a corrupted fixture, or Docker.
+// That sentinel is exactly the value that crashed
+// ``MissingMethodException`` before PR #11 added the filter guards in
+// workflows/nanometanf.nf and the destructuring closures downstream.
+//
+// Keeping the override scoped to this single test file means the
+// rest of the test matrix (multiplex_scaling, full_pipeline_stubmode,
+// etc.) still exercises CHOPPER normally.
+
+process {
+    withName: 'CHOPPER' {
+        ext.when = false
+    }
+}

--- a/tests/ifempty_sentinel_regression.nf.test
+++ b/tests/ifempty_sentinel_regression.nf.test
@@ -1,0 +1,82 @@
+nextflow_pipeline {
+
+    name "ifEmpty([]) sentinel regression (audit V4 / PR #11 P0.1)"
+    script "../main.nf"
+
+    // Regression cover for the May 4 2026 incident where every CHOPPER
+    // task in a real run failed, the qc_analysis subworkflow injected
+    // the ``[]`` sentinel via ``.ifEmpty([])`` (still does, by design
+    // -- the top-level test framework asserts on the channel emission),
+    // and the destructuring closures in the main workflow + the
+    // taxonomic_classification subworkflow then crashed with
+    //
+    //   groovy.lang.MissingMethodException:
+    //   Invalid method invocation `call` with arguments: [] (ArrayList)
+    //
+    // PR #11's P0.1 fix added ``.filter { it instanceof List && it.size() >= 2 && it[0] instanceof Map }``
+    // filters in front of every consuming closure. This test forces
+    // the exact upstream condition (empty CHOPPER output channel)
+    // without running the CHOPPER binary, so it stays inside the
+    // host-only stub matrix and does not require Docker.
+    //
+    // Mechanism: the sibling .config sets ``ext.when = false`` on the
+    // CHOPPER process. Nextflow skips scheduling -- the output channel
+    // is genuinely empty -- ``.ifEmpty([])`` injects ``[]`` -- the PR
+    // #11 filters drop it -- the workflow exits cleanly with no QC
+    // outputs to publish.
+
+    tag "pipeline"
+    tag "regression"
+    tag "ifempty"
+    tag "core"
+    tag "stub"
+
+    test("Pipeline exits without MissingMethodException when CHOPPER output channel is empty") {
+
+        config "./ifempty_sentinel_regression.config"
+        options "-stub"
+
+        when {
+            params {
+                input = "$projectDir/assets/test_samplesheet.csv"
+                outdir = "$outputDir"
+
+                realtime_mode = false
+                skip_kraken2 = true
+                blast_validation = false
+
+                // qc_tool=chopper is the default; explicit here so the
+                // intent is obvious. The .config disables CHOPPER
+                // scheduling via ext.when=false, leaving the CHOPPER
+                // output channel empty and triggering the
+                // ``CHOPPER.out.fastq.ifEmpty([])`` sentinel path.
+                qc_tool = 'chopper'
+
+                skip_fastp = false
+                skip_nanoplot = true
+
+                max_cpus = 2
+                max_memory = '4.GB'
+                max_time = '5.min'
+            }
+        }
+
+        then {
+            // The destructuring closures must survive the ``[]``
+            // sentinel. The exact crash signatures from the May 4
+            // incident were:
+            //   - "MissingMethodException"
+            //   - "Invalid method invocation `call` with arguments: []"
+            // Neither may appear in the workflow error report. We do
+            // not assert on workflow.success: with QC disabled there
+            // may be no reads downstream and the pipeline can
+            // legitimately abort with an empty-output error -- what
+            // matters is that the error is not the destructuring
+            // crash.
+            def err = (workflow.errorReport ?: '') + '\n' + (workflow.stdout?.join('\n') ?: '')
+            assert !err.contains('MissingMethodException')
+            assert !err.contains('Invalid method invocation `call`')
+            assert !err.contains('Cannot invoke method `call` with arguments')
+        }
+    }
+}

--- a/workflows/nanometanf.nf
+++ b/workflows/nanometanf.nf
@@ -499,8 +499,16 @@ workflow NANOMETANF {
     // MODULE: Generate nanopore-specific MultiQC custom content (optional)
     //
     if (params.enable_nanopore_stats_mqc) {
-        // Collect SeqKit/FASTP stats as file inputs for nanopore statistics
+        // Collect SeqKit/FASTP stats as file inputs for nanopore statistics.
+        // The upstream QC_ANALYSIS subworkflow attaches ``.ifEmpty([])`` to
+        // ``qc_json`` so the top-level test harness sees an emission even
+        // when every QC task failed. That synthetic ``[]`` placeholder
+        // must be dropped before any tuple-destructuring closure
+        // ``{ meta, stats_file -> ... }``; otherwise it crashes with
+        // ``MissingMethodException``. Same guard pattern as in the
+        // ``QC_ANALYSIS.out.qc_json.collect{ it[1] }`` consumers above.
         ch_stats_files = QC_ANALYSIS.out.qc_json
+            .filter { it instanceof List && it.size() >= 2 && it[1] != null }
             .map { meta, stats_file -> stats_file }
             .collect()
 


### PR DESCRIPTION
## Summary

Audit verification V4 asked for "a fixture in which CHOPPER is forced to fail for every sample" so we can prove the May 4 \`MissingMethodException\` cannot return. The earlier reasoning that this needed Docker + a corrupted FASTQ was wrong: the test does not need CHOPPER to **fail** at runtime, it only needs CHOPPER's **output channel to be empty** so \`qc_analysis\`'s \`CHOPPER.out.fastq.ifEmpty([])\` injects the \`[]\` sentinel that crashed the consumers.

A test-only \`tests/ifempty_sentinel_regression.config\` flips \`ext.when = false\` on CHOPPER. Nextflow skips scheduling, the output channel is genuinely empty, the sentinel fires exactly the way it did during the incident — no binary, no corrupted fixture, no Docker.

### Real regression found

Building the test surfaced a missed call site from PR #11. \`workflows/nanometanf.nf:503-505\` still had an unguarded \`QC_ANALYSIS.out.qc_json.map { meta, stats_file -> stats_file }\` closure inside the \`enable_nanopore_stats_mqc\` branch (default \`true\`). The new test reproduced the exact original crash signature against this code path:

\`\`\`
groovy.lang.MissingMethodException: No signature of method:
_nf_script_<hash>$_runScript_closure1$_closure2$_closure22.call()
is applicable for argument types: (ArrayList) values: [[]]
\`\`\`

Apply the PR #11 filter pattern (\`filter { it instanceof List && it.size() >= 2 && it[1] != null }\`) before the destructuring closure. The V4 test passes after the fix and serves as the regression cover this case never had.

## Test plan

- [x] \`nf-test test tests/ifempty_sentinel_regression.nf.test tests/multiplex_scaling.nf.test tests/full_pipeline_stubmode.nf.test\` — 8/8 PASS locally (~130 s).
- [x] \`nf-core pipelines schema lint\` — clean (120 params).
- [x] \`pre-commit run\` — clean on all touched files.
- [ ] CI matrix (nf-test 26.04.0 + latest-everything, profile-sanity, verify-pipeline, lint).

## CI wiring

- \`.github/workflows/nf-test.yml\` — new file added to the explicit nf-test list.
- \`.nf-core.yml\` — added to the \`nf_test_content\` skip list (no versions.yml snapshot, matching existing pipeline-level entries).

## Audit context

Audit plan at \`/Users/andreassjodin/.claude/plans/make-an-audit-of-steady-iverson.md\`. This closes V4. After PR #17 (V5) the remaining items are V2 expansion (subworkflow/module tests blocked on watchPath hang) and V5 field-run (real-hardware run, not a code task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)