### PR TITLE
ci(v2): expand nf-test scope to every module + non-realtime subworkflow

### DIFF
--- a/.github/workflows/nf-test.yml
+++ b/.github/workflows/nf-test.yml
@@ -64,14 +64,20 @@ jobs:
         # FASTP / FASTQC etc. resolve their containers instead of
         # hitting ``exit 127`` for the missing host binary.
         #
-        # All tests/realtime_*.nf.test cases are excluded explicitly
-        # because they exercise watchPath, which still leaks the
-        # FileAlterationMonitor thread on the GitHub runner and hangs
-        # the job past the 45 min cap (the 26.04.0 fix claim in
+        # The test path list intentionally enumerates every file under
+        # ``tests/``, ``modules/local/*/tests/``, and
+        # ``subworkflows/local/*/tests/`` EXCEPT
+        # ``subworkflows/local/realtime_monitoring/tests/main.nf.test``.
+        # The realtime_monitoring file declares ``tag "hangs-on-jvm-cleanup"``
+        # on three watchPath tests because the
+        # FileAlterationMonitor thread leaks on the GitHub runner and
+        # hangs the job past the 45 min cap (the 26.04.0 fix claim in
         # docs/upstream-issues/26-watchpath-cleanup-hang.md does not
-        # hold on this runner image). Realtime coverage stays in local
-        # development runs; the rest of the integration matrix runs in
-        # CI.
+        # hold on this runner image). nf-test 0.9.5 lacks
+        # ``--exclude-tag`` and the file declares ``core`` at file
+        # scope, so positive tag filtering cannot skip the hanging
+        # tests; enumerating paths is the only mechanism left.
+        # Realtime coverage stays in local development runs.
         run: |
           nf-test test --profile test,docker \
             --tag fast --tag core --tag stub --tag integration \
@@ -87,7 +93,41 @@ jobs:
             tests/multiplex_scaling.nf.test \
             tests/nanoseq_test.nf.test \
             tests/parameter_validation.nf.test \
-            tests/qc_tool_integration.nf.test
+            tests/qc_tool_integration.nf.test \
+            modules/local/aggregate_validation_results/tests/main.nf.test \
+            modules/local/blastn_validation/tests/main.nf.test \
+            modules/local/canonical_assembly_writer/tests/main.nf.test \
+            modules/local/canonical_classification_writer/tests/main.nf.test \
+            modules/local/canonical_qc_writer/tests/main.nf.test \
+            modules/local/canonical_validation_writer/tests/main.nf.test \
+            modules/local/emit_empty_kraken2_report/tests/main.nf.test \
+            modules/local/extract_reads_by_taxid/tests/main.nf.test \
+            modules/local/fastp_streaming/tests/main.nf.test \
+            modules/local/generate_realtime_report/tests/main.nf.test \
+            modules/local/generate_snapshot_stats/tests/main.nf.test \
+            modules/local/kraken2_db_preload/tests/main.nf.test \
+            modules/local/kraken2_final_aggregator/tests/main.nf.test \
+            modules/local/kraken2_incremental_classifier/tests/main.nf.test \
+            modules/local/kraken2_optimized/tests/main.nf.test \
+            modules/local/kraken2_output_merger/tests/main.nf.test \
+            modules/local/kraken2_report_generator/tests/main.nf.test \
+            modules/local/manifest_writer/tests/main.nf.test \
+            modules/local/minimap2_validation/tests/main.nf.test \
+            modules/local/multiqc_nanopore_stats/tests/main.nf.test \
+            modules/local/nanoplot_compare/tests/main.nf.test \
+            modules/local/seqkit_merge_stats/tests/main.nf.test \
+            modules/local/update_cumulative_stats/tests/main.nf.test \
+            subworkflows/local/assembly/tests/main.nf.test \
+            subworkflows/local/demultiplexing/tests/main.nf.test \
+            subworkflows/local/input_scanner/tests/main.nf.test \
+            subworkflows/local/qc_analysis/tests/main.nf.test \
+            subworkflows/local/qc_benchmark/tests/main.nf.test \
+            subworkflows/local/realtime_statistics/tests/main.nf.test \
+            subworkflows/local/taxonomic_classification/tests/gui_filename_compatibility.nf.test \
+            subworkflows/local/taxonomic_classification/tests/main.nf.test \
+            subworkflows/local/taxonomic_classification/tests/realtime_cumulative_emit.nf.test \
+            subworkflows/local/utils_nfcore_nanometanf_pipeline/tests/main.nf.test \
+            subworkflows/local/validation/tests/main.nf.test
 
   profile-sanity:
     # Stub-mode sanity check that each platform profile loads cleanly,


### PR DESCRIPTION
## Summary

Audit verification item **V2** asked for the full nf-test suite to run in CI. The previous workflow scoped to 13 top-level files in \`tests/\` because the only structural blocker was \`subworkflows/local/realtime_monitoring/tests/main.nf.test\` whose three \`hangs-on-jvm-cleanup\`-tagged watchPath tests leak the FileAlterationMonitor thread on the GitHub runner and hang past the 45 min cap. nf-test 0.9.5 has no \`--exclude-tag\` and that file declares \`core\` at file scope, so positive tag filtering picks it up.

**Mechanism**: enumerate every other test file under \`modules/local/*/tests/\` (23 files) and \`subworkflows/local/*/tests/\` (11 files except the hang file) into the explicit \`nf-test test\` argument list. The \`--profile test,docker\` already in the command makes the runner pull each module's declared container.

### New CI coverage

| Category | Files in CI |
|---|---|
| Pipeline-level integration (\`tests/\`) | 13 (unchanged) |
| Module-internal (\`modules/local/*/tests/\`) | 23 (new) |
| Subworkflow-internal (\`subworkflows/local/*/tests/\`) | 11 (new) |

Only the three known-hanging realtime tests remain deferred to local runs, tracked in \`docs/upstream-issues/26-watchpath-cleanup-hang.md\`.

## Test plan

- [x] Local sanity sample: 8 stub tests across merger / report_generator / final_aggregator / qc_analysis PASS in 32 s.
- [ ] Full CI matrix — nf-test job runtime expected to grow from ~16 min to ~25-30 min with the added 34 files.

## Audit context

Closes the audit V2 verification item. After this PR, only audit V5-live (a real-hardware 24-barcode run with the metrics enabled) remains — that one is not a coding task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)