### PR TITLE
fix(validation): don't inject empty list into versions in batch mode

### DIFF
--- a/subworkflows/local/validation/main.nf
+++ b/subworkflows/local/validation/main.nf
@@ -122,7 +122,13 @@ workflow VALIDATION {
     }
 
     EXTRACT_READS_BY_TAXID(ch_extraction_input)
-    ch_versions = ch_versions.mix(EXTRACT_READS_BY_TAXID.out.versions.first().ifEmpty([]))
+    // Use .first() to collapse the per-taxid scatter to a single versions
+    // entry. Do NOT add .ifEmpty([]) -- a skipped process (e.g. a cumulative
+    // aggregator in batch mode) would then inject an empty list `[]` into
+    // ch_versions, and the nf-core softwareVersionsToYAML helper calls
+    // Yaml.load() on each item, which throws MethodSelectionException on a
+    // List. An empty channel mixed in contributes nothing, which is correct.
+    ch_versions = ch_versions.mix(EXTRACT_READS_BY_TAXID.out.versions.first())
 
     //
     // Prepare validation input by combining extracted reads with genome references
@@ -173,7 +179,7 @@ workflow VALIDATION {
         )
         ch_blast_stats = BLASTN_VALIDATION.out.stats.map { meta, stats -> stats }.ifEmpty([])
         ch_blast_results = BLASTN_VALIDATION.out.results.ifEmpty([])
-        ch_versions = ch_versions.mix(BLASTN_VALIDATION.out.versions.first().ifEmpty([]))
+        ch_versions = ch_versions.mix(BLASTN_VALIDATION.out.versions.first())
 
         // Realtime only: maintain a run-so-far cumulative BLAST table + stats per
         // (sample, taxid). Pair this batch's table with its stats (for the
@@ -192,7 +198,7 @@ workflow VALIDATION {
                   prior_stats.exists() ? prior_stats : [] ]
             }
         BLAST_CUMULATIVE_AGGREGATOR(ch_blast_cumulative_input, 'blast')
-        ch_versions = ch_versions.mix(BLAST_CUMULATIVE_AGGREGATOR.out.versions.first().ifEmpty([]))
+        ch_versions = ch_versions.mix(BLAST_CUMULATIVE_AGGREGATOR.out.versions.first())
     }
 
     //
@@ -211,7 +217,7 @@ workflow VALIDATION {
         )
         ch_minimap2_stats = MINIMAP2_VALIDATION.out.stats.map { meta, stats -> stats }.ifEmpty([])
         ch_minimap2_results = MINIMAP2_VALIDATION.out.alignments.ifEmpty([])
-        ch_versions = ch_versions.mix(MINIMAP2_VALIDATION.out.versions.first().ifEmpty([]))
+        ch_versions = ch_versions.mix(MINIMAP2_VALIDATION.out.versions.first())
 
         // Realtime only: maintain a run-so-far cumulative PAF + stats per
         // (sample, taxid). See the BLAST branch above for the rationale.
@@ -227,7 +233,7 @@ workflow VALIDATION {
                   prior_stats.exists() ? prior_stats : [] ]
             }
         MINIMAP2_CUMULATIVE_AGGREGATOR(ch_minimap2_cumulative_input, 'minimap2')
-        ch_versions = ch_versions.mix(MINIMAP2_CUMULATIVE_AGGREGATOR.out.versions.first().ifEmpty([]))
+        ch_versions = ch_versions.mix(MINIMAP2_CUMULATIVE_AGGREGATOR.out.versions.first())
     }
 
     //

--- a/subworkflows/local/validation/tests/main.nf.test
+++ b/subworkflows/local/validation/tests/main.nf.test
@@ -1,0 +1,97 @@
+nextflow_workflow {
+
+    name "Test VALIDATION subworkflow"
+    script "../main.nf"
+    workflow "VALIDATION"
+
+    // Test Level & Component
+    tag "subworkflow"
+    tag "validation"
+
+    // Feature Area
+    tag "regression"
+
+    // Execution Speed & Criticality
+    tag "fast"
+    tag "core"
+    tag "stub"
+
+    // Regression cover for the June 4 2026 batch-mode crash: in batch mode
+    // ``meta`` carries no ``batch_id``, so the realtime cumulative aggregators
+    // (MINIMAP2_/BLAST_CUMULATIVE_AGGREGATOR) are skipped. The version mixes
+    // previously used ``.first().ifEmpty([])``, so a skipped aggregator
+    // injected an empty list ``[]`` into the emitted ``versions`` channel. At
+    // the pipeline level the nf-core ``softwareVersionsToYAML`` helper then
+    // called ``Yaml.load([])`` and aborted the run with MethodSelectionException.
+    // The fix drops ``.ifEmpty([])`` (an empty channel contributes nothing), so
+    // ``versions`` must contain only real files and never an empty list.
+
+    test("batch-mode minimap2 validation emits no empty-list versions entry") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                // meta WITHOUT batch_id => batch mode => cumulative aggregator skipped
+                input[0] = Channel.of([ [id: 'val_batch', single_end: true],
+                             file('${projectDir}/tests/fixtures/fastq/test_sample.fastq.gz') ])
+                input[1] = Channel.of([ [id: 'val_batch', single_end: true],
+                             file('${projectDir}/tests/fixtures/validation/test_kraken_output.txt') ])
+                input[2] = Channel.of([ [id: 'val_batch', single_end: true],
+                             file('${projectDir}/tests/fixtures/reports/classification/kraken2_report.txt') ])
+                input[3] = file('${projectDir}/tests/fixtures/validation/test_genomes.json')
+                input[4] = 'all'
+                input[5] = 'minimap2'
+                """
+            }
+
+            params {
+                max_cpus = 2
+                max_memory = '4.GB'
+                max_time = '5.min'
+            }
+        }
+
+        then {
+            assert workflow.success
+            // The regression: no emitted versions item may be an empty list.
+            assert !workflow.out.versions.any { it instanceof List && it.isEmpty() }
+            // And real version files must still be collected.
+            assert workflow.out.versions.size() > 0
+        }
+    }
+
+    test("batch-mode blast validation emits no empty-list versions entry") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = Channel.of([ [id: 'val_batch', single_end: true],
+                             file('${projectDir}/tests/fixtures/fastq/test_sample.fastq.gz') ])
+                input[1] = Channel.of([ [id: 'val_batch', single_end: true],
+                             file('${projectDir}/tests/fixtures/validation/test_kraken_output.txt') ])
+                input[2] = Channel.of([ [id: 'val_batch', single_end: true],
+                             file('${projectDir}/tests/fixtures/reports/classification/kraken2_report.txt') ])
+                input[3] = file('${projectDir}/tests/fixtures/validation/test_genomes.json')
+                input[4] = 'all'
+                input[5] = 'blast'
+                """
+            }
+
+            params {
+                max_cpus = 2
+                max_memory = '4.GB'
+                max_time = '5.min'
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert !workflow.out.versions.any { it instanceof List && it.isEmpty() }
+            assert workflow.out.versions.size() > 0
+        }
+    }
+}

--- a/workflows/nanometanf.nf
+++ b/workflows/nanometanf.nf
@@ -486,7 +486,12 @@ workflow NANOMETANF {
             "${process}:\n${tool_versions.join('\n')}"
         }
 
-    softwareVersionsToYAML(ch_versions.mix(topic_versions.versions_file))
+    // Guard: softwareVersionsToYAML calls Yaml.load() on each item, which throws
+    // MethodSelectionException for a List or null. A skipped subworkflow process
+    // can otherwise inject an empty list `[]` into ch_versions (see the validation
+    // subworkflow). Drop any non-file item so version collection can never abort
+    // the run.
+    softwareVersionsToYAML(ch_versions.filter { it != null && !(it instanceof List) }.mix(topic_versions.versions_file))
         .mix(topic_versions_string)
         .collectFile(
             storeDir: "${params.outdir}/pipeline_info",


### PR DESCRIPTION
## Problem
Running pathogen validation (BLAST or minimap2) in **batch mode** aborted the
entire pipeline:

```
ERROR nextflow.extension.OperatorImpl
org.codehaus.groovy.runtime.metaclass.MethodSelectionException:
  Could not find which method load() to invoke ... org.yaml.snakeyaml.Yaml#load(...)
  at processVersionsFromYAML / softwareVersionsToYAML
```

Confirmed from a user's run logs: a run **without** validation completed fine; a
run **with** validation crashed right after `MINIMAP2_VALIDATION`, killing
`AGGREGATE_VALIDATION_RESULTS`.

## Root cause
In batch mode `meta` carries no `batch_id`, so the realtime cumulative
aggregators (`MINIMAP2_CUMULATIVE_AGGREGATOR` / `BLAST_CUMULATIVE_AGGREGATOR`)
are skipped (their input is filtered to `meta.batch_id`). The version mixes used
`…out.versions.first().ifEmpty([])`, so a skipped process injected an empty list
`[]` into `ch_versions`. The nf-core `softwareVersionsToYAML` helper then calls
`Yaml.load([])`, which matches none of the overloads → `MethodSelectionException`.
(The prior fix `65d23cb` addressed versions emission *when the aggregator runs*,
not this skip-injection case.)

## Fix
- `subworkflows/local/validation/main.nf`: drop `.ifEmpty([])` from all five
  version mixes. `.first()` on an empty channel emits nothing, so a skipped
  process contributes nothing instead of `[]`.
- `workflows/nanometanf.nf`: filter null / non-`Path` (List) items out of
  `ch_versions` before `softwareVersionsToYAML` as a defensive guard so a future
  skipped-process injection can never abort version collection.

## Test
Adds `subworkflows/local/validation/tests/main.nf.test`: batch-mode (no
`batch_id`) minimap2 and blast runs assert the emitted `versions` channel
contains no empty list. Both pass (stub mode). The existing
`tests/full_pipeline_stubmode.nf.test` (4 cases) remains green.

## Deployment note
The server runs `pipeline_source: remote:dev` and Nextflow cached the clone at
the old commit. After merging this to `dev`, re-pull the pipeline on the server
(`nextflow pull foi-bioinformatics/nanometanf`, or clear the cached clone under
`<results>/.nextflow/assets`) so the fix is picked up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)