### PR TITLE
test(validation): stub matrix for validation+assembly; fix 2 bugs it found

### DIFF
--- a/subworkflows/local/assembly/main.nf
+++ b/subworkflows/local/assembly/main.nf
@@ -48,7 +48,10 @@ workflow ASSEMBLY {
             ch_reads,
             sequencing_mode
         )
-        ch_versions = ch_versions.mix(FLYE.out.versions)
+        // FLYE emits its version via `topic: versions` (versions_flye); it is
+        // collected centrally in the top-level workflow. There is no
+        // `FLYE.out.versions` to mix here -- referencing it throws
+        // MissingPropertyException and aborts the run.
 
         // Collect standardized outputs
         ch_assembly = FLYE.out.fasta.ifEmpty([])
@@ -66,7 +69,7 @@ workflow ASSEMBLY {
             false,                       // cigar_paf_format
             false                        // cigar_bam
         )
-        ch_versions = ch_versions.mix(MINIMAP2_ALIGN.out.versions)
+        // MINIMAP2_ALIGN emits its version via `topic: versions`; collected centrally.
 
         //
         // MODULE: Run Miniasm for ultra-fast assembly
@@ -77,7 +80,7 @@ workflow ASSEMBLY {
         MINIASM (
             ch_miniasm_input
         )
-        ch_versions = ch_versions.mix(MINIASM.out.versions)
+        // MINIASM emits its version via `topic: versions`; collected centrally.
 
         // Collect standardized outputs
         ch_assembly = MINIASM.out.assembly.ifEmpty([])

--- a/subworkflows/local/validation/main.nf
+++ b/subworkflows/local/validation/main.nf
@@ -27,6 +27,20 @@ workflow VALIDATION {
     main:
     ch_versions = Channel.empty()
 
+    // The classification subworkflow attaches `.ifEmpty([])` sentinels to these
+    // channels, so a sample with no classified reads (e.g. a negative control,
+    // or the EMIT_EMPTY_KRAKEN2_REPORT placeholder) emits the `[]` sentinel.
+    // The joins/combines and `{ meta, ... -> }` maps below would then be called
+    // with `[]` and abort the run with MissingMethodException. Drop the sentinel
+    // at the boundary so an empty sample simply yields no validation tasks; the
+    // aggregator already tolerates an empty result via `.collect().ifEmpty([])`.
+    ch_classified_reads = ch_classified_reads
+        .filter { it instanceof List && it.size() >= 2 && it[0] instanceof Map }
+    ch_kraken_output = ch_kraken_output
+        .filter { it instanceof List && it.size() >= 2 && it[0] instanceof Map }
+    ch_kraken_reports = ch_kraken_reports
+        .filter { it instanceof List && it.size() >= 2 && it[0] instanceof Map }
+
     //
     // Parse pathogen genomes JSON to get taxid -> genome/database path mapping
     // JSON format: { "taxid": "/path/to/genome.fasta", ... }
@@ -255,14 +269,23 @@ workflow VALIDATION {
     if (params.write_canonical != false) {
         def ch_for_canonical = Channel.empty()
 
+        // ch_blast_results / ch_minimap2_results carry an `.ifEmpty([])`
+        // sentinel (set above), so when validation produced no alignments they
+        // emit `[]`. Filter the sentinel before the `{ meta, f -> ... }` map, or
+        // the closure is called with `[]` and the run aborts. The post-mix
+        // filter below only guards the downstream consumer, not these maps.
         if (validation_method == 'blast' || validation_method == 'both') {
             ch_for_canonical = ch_for_canonical.mix(
-                ch_blast_results.map { meta, f -> [meta, f, "blast", "blast"] }
+                ch_blast_results
+                    .filter { it instanceof List && it.size() >= 2 && it[0] instanceof Map }
+                    .map { meta, f -> [meta, f, "blast", "blast"] }
             )
         }
         if (validation_method == 'minimap2' || validation_method == 'both') {
             ch_for_canonical = ch_for_canonical.mix(
-                ch_minimap2_results.map { meta, f -> [meta, f, "minimap2", "paf"] }
+                ch_minimap2_results
+                    .filter { it instanceof List && it.size() >= 2 && it[0] instanceof Map }
+                    .map { meta, f -> [meta, f, "minimap2", "paf"] }
             )
         }
 

--- a/tests/validation_assembly_stub_matrix.nf.test
+++ b/tests/validation_assembly_stub_matrix.nf.test
@@ -1,0 +1,126 @@
+nextflow_pipeline {
+
+    name "Validation + assembly stub matrix (run completes, versions written)"
+    script "../main.nf"
+
+    // Closes the coverage gap that let the batch-mode validation crash ship:
+    // no test exercised the validation/assembly integration path, so the
+    // ch_versions assembly and the software-versions writer were never run
+    // end-to-end. These stub-mode cases run the full pipeline with validation
+    // (blast / minimap2 / both) and with assembly enabled, in batch mode, and
+    // assert three things per case:
+    //   (#2) the error report is free of the Groovy channel-shape / destructuring
+    //        crash family (MethodSelectionException from Yaml.load([]),
+    //        MissingMethodException, "Invalid method invocation `call`"),
+    //   (#3) pipeline_info/*software_versions* is actually written (version
+    //        collection was the abort point of the original bug), and
+    //        the run succeeds.
+
+    tag "pipeline"
+    tag "integration"
+    tag "validation"
+    tag "assembly"
+    tag "stub"
+    tag "core"
+
+    test("batch + minimap2 validation: run completes, versions written") {
+        options "-stub"
+        when {
+            params {
+                input = "$projectDir/tests/fixtures/samplesheets/minimal.csv"
+                outdir = "$outputDir"
+                classifier = 'kraken2'
+                kraken2_db = "$projectDir/tests/fixtures/kraken2_db"
+                realtime_mode = false
+                run_validation = true
+                validation_method = 'minimap2'
+                pathogen_genomes = "$projectDir/tests/fixtures/validation/test_genomes.json"
+                skip_nanoplot = true
+                max_cpus = 2
+                max_memory = '4.GB'
+                max_time = '5.min'
+            }
+        }
+        then {
+            def err = (workflow.errorReport ?: '') + '\n' + (workflow.stdout?.join('\n') ?: '')
+            assert !err.contains('MethodSelectionException')
+            assert !err.contains('Could not find which method')
+            assert !err.contains('MissingMethodException')
+            assert !err.contains('Invalid method invocation `call`')
+            assert workflow.success
+            assert path("$outputDir/pipeline_info").list()
+                .any { it.toString().contains('software_') }
+        }
+    }
+
+    test("batch + blast validation: run completes, versions written") {
+        options "-stub"
+        when {
+            params {
+                input = "$projectDir/tests/fixtures/samplesheets/minimal.csv"
+                outdir = "$outputDir"
+                classifier = 'kraken2'
+                kraken2_db = "$projectDir/tests/fixtures/kraken2_db"
+                realtime_mode = false
+                run_validation = true
+                validation_method = 'blast'
+                pathogen_genomes = "$projectDir/tests/fixtures/validation/test_genomes.json"
+                skip_nanoplot = true
+                max_cpus = 2
+                max_memory = '4.GB'
+                max_time = '5.min'
+            }
+        }
+        then {
+            def err = (workflow.errorReport ?: '') + '\n' + (workflow.stdout?.join('\n') ?: '')
+            assert !err.contains('MethodSelectionException')
+            assert !err.contains('Could not find which method')
+            assert !err.contains('MissingMethodException')
+            assert !err.contains('Invalid method invocation `call`')
+            assert workflow.success
+            assert path("$outputDir/pipeline_info").list()
+                .any { it.toString().contains('software_') }
+        }
+    }
+
+    test("batch + both validation methods: run completes, versions written") {
+        options "-stub"
+        when {
+            params {
+                input = "$projectDir/tests/fixtures/samplesheets/minimal.csv"
+                outdir = "$outputDir"
+                classifier = 'kraken2'
+                kraken2_db = "$projectDir/tests/fixtures/kraken2_db"
+                realtime_mode = false
+                run_validation = true
+                validation_method = 'both'
+                pathogen_genomes = "$projectDir/tests/fixtures/validation/test_genomes.json"
+                skip_nanoplot = true
+                max_cpus = 2
+                max_memory = '4.GB'
+                max_time = '5.min'
+            }
+        }
+        then {
+            def err = (workflow.errorReport ?: '') + '\n' + (workflow.stdout?.join('\n') ?: '')
+            assert !err.contains('MethodSelectionException')
+            assert !err.contains('Could not find which method')
+            assert !err.contains('MissingMethodException')
+            assert !err.contains('Invalid method invocation `call`')
+            assert workflow.success
+            assert path("$outputDir/pipeline_info").list()
+                .any { it.toString().contains('software_') }
+        }
+    }
+
+    // NOTE on assembly: enable_assembly=true is NOT covered by a full stub run
+    // here because the FLYE module collects its version via
+    // `eval('flye --version')` on a `topic: versions` output, which runs the
+    // tool even under `-stub` and fails when flye is not installed (no
+    // container in the host-only stub matrix). The production bug that this
+    // matrix originally exposed -- `FLYE.out.versions` (MissingPropertyException,
+    // the module emits `versions_flye` via the topic, not `.out.versions`) -- is
+    // fixed in subworkflows/local/assembly/main.nf; with the fix the assembly
+    // path no longer aborts on the version reference. A full assembly run is
+    // exercised by the conda/container test profiles, not by this stub matrix.
+}

--- a/workflows/nanometanf.nf
+++ b/workflows/nanometanf.nf
@@ -417,25 +417,41 @@ workflow NANOMETANF {
 
         // Collect canonical writer outputs so manifest runs after all files are published.
         // Each subworkflow emits canonical outputs only when write_canonical is enabled.
+        // The subworkflows attach `.ifEmpty([])` to these channels, so an empty
+        // stage (e.g. no classified reads -> EMIT_EMPTY_KRAKEN2_REPORT, or a
+        // negative-control sample) emits the `[]` sentinel. Filter it out before
+        // the `{ meta, f -> f }` destructuring map -- otherwise the closure is
+        // called with `[]` and the run aborts with MissingMethodException. Same
+        // guard pattern as the QC-path sentinel fix (PR #11). Use an inline
+        // closure (not a closure variable): `.filter(var)` can be dispatched as
+        // a value/equality filter rather than a predicate.
         def ch_canonical_done = Channel.empty()
         if (!params.skip_fastp || !params.skip_nanoplot) {
             ch_canonical_done = ch_canonical_done.mix(
-                QC_ANALYSIS.out.canonical_qc.map { meta, f -> f }
+                QC_ANALYSIS.out.canonical_qc
+                    .filter { it instanceof List && it.size() >= 2 && it[0] instanceof Map }
+                    .map { meta, f -> f }
             )
         }
         if (params.kraken2_db && !params.skip_kraken2) {
             ch_canonical_done = ch_canonical_done.mix(
-                TAXONOMIC_CLASSIFICATION.out.canonical_classification.map { meta, f -> f }
+                TAXONOMIC_CLASSIFICATION.out.canonical_classification
+                    .filter { it instanceof List && it.size() >= 2 && it[0] instanceof Map }
+                    .map { meta, f -> f }
             )
         }
         if (params.enable_assembly) {
             ch_canonical_done = ch_canonical_done.mix(
-                ASSEMBLY.out.canonical_assembly.map { meta, f -> f }
+                ASSEMBLY.out.canonical_assembly
+                    .filter { it instanceof List && it.size() >= 2 && it[0] instanceof Map }
+                    .map { meta, f -> f }
             )
         }
         if (run_validation_effective && params.pathogen_genomes) {
             ch_canonical_done = ch_canonical_done.mix(
-                VALIDATION.out.canonical_alignments.map { meta, f -> f }
+                VALIDATION.out.canonical_alignments
+                    .filter { it instanceof List && it.size() >= 2 && it[0] instanceof Map }
+                    .map { meta, f -> f }
             )
         }
 


### PR DESCRIPTION
Implements nf-test extensions #1/#2/#3 from the test-coverage discussion, and
fixes the two real pre-existing bugs the new matrix immediately exposed.

## New test (#1/#2/#3)
`tests/validation_assembly_stub_matrix.nf.test` runs the **full pipeline in stub
mode with validation enabled** (blast / minimap2 / both, batch mode) — the
integration path that previously had **zero** coverage (no test set
`run_validation`/`pathogen_genomes`, which is how the original batch-validation
crash shipped). Each case asserts:
- **#2** the error report is free of the Groovy channel-shape / destructuring
  crash family (`MethodSelectionException`, `MissingMethodException`,
  `` `call` with arguments: [] ``);
- **#3** `pipeline_info/*software_versions*` is actually written (version
  collection was the abort point of the original bug);
- and `workflow.success`.

## Bugs the matrix found (both fixed)
1. **Empty-classification crash.** A sample with no classified reads (negative
   control / `EMIT_EMPTY_KRAKEN2_REPORT` placeholder) emits the `.ifEmpty([])`
   `[]` sentinel, which the VALIDATION subworkflow destructured in its
   join/combine/`{ meta,... }` maps → `MissingMethodException`, aborting any run
   with validation enabled on such a sample. Fixed by filtering the sentinel at
   the VALIDATION input boundary and before the canonical-alignment maps over
   `ch_blast_results`/`ch_minimap2_results`; plus a defensive guard on the
   canonical-done maps in `workflows/nanometanf.nf`.
2. **Assembly broken.** `enable_assembly=true` aborted at `assembly/main.nf:51`
   (`No such property: versions`) — FLYE/MINIMAP2_ALIGN/MINIASM emit versions via
   `topic: versions` (`versions_flye` etc.), so `.out.versions` doesn't exist.
   Removed the three invalid manual mixes (versions are collected centrally via
   the topic).

## Verification
10 tests pass: validation subworkflow (2), full_pipeline_stubmode (4), ifEmpty
sentinel regression (1), new matrix (3). No regressions.

Note: the assembly path is documented as not stub-coverable here because FLYE's
`eval('flye --version')` runs even under `-stub`; the production fix is verified
by the `No such property` crash no longer occurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)